### PR TITLE
Add support for SNI servers

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function isH2( url, options ) {
       }
 
       exec(
-        'true | openssl s_client -connect ' + url + ':443 -nextprotoneg ""',
+        'true | openssl s_client -connect ' + url + ':443 -servername ' + url + ' -nextprotoneg ""',
         function( error, result ) {
           if ( error ) {
             if (


### PR DESCRIPTION
by sending servername parameter to openssl.

Required for a lot of servers serving different certificates based on the sent hostname, like CloudFlare Universal SSL.
I have not been able to find any downside yet, but be aware I'm not a protocol or openssl expert.

Before:
$ is-http2 karlbowden.com
× HTTP/2 not supported by karlbowden.com

After:
is-http2 karlbowden.com
✓ HTTP/2 supported by karlbowden.com
Supported protocols: h2 spdy/3.1 http/1.1
