### PR TITLE
Use custom openssl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ To make `is-http2` work, you need to have [openssl](http://openssl.org/) in a ve
 
 **url** : Url to check HTTP/2 support for
 
-**options.includeSpdy** : should SPDY be considered HTTP/2
+#### Options 
+* **includeSpdy** : optional: should SPDY be considered HTTP/2
+* **openssl** : optional: specify custom openssl command (i.e. '/usr/local/Cellar/openssl/1.0.2k/bin/openssl') 
+
 
 `isHttp2` returns a Promise which will be resolved with an Object containing `isHttp2` and `supportedProtocols`.
 

--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ var isH2Util     = require( './util' );
  */
 function isH2( url, options ) {
   options = options || {};
+  var openssl = options.openssl || 'openssl';
 
   return new Promise( function( resolve, reject ) {
-    exec( 'openssl version', function( error, result ) {
+    exec( openssl + ' version', function( error, result ) {
       if ( error ) {
         if ( error.code === 127 ) {
           return reject(
@@ -53,7 +54,7 @@ function isH2( url, options ) {
       }
 
       exec(
-        'true | openssl s_client -connect ' + url + ':443 -servername ' + url + ' -nextprotoneg ""',
+        'true | ' + openssl + ' s_client -connect ' + url + ':443 -servername ' + url + ' -nextprotoneg ""',
         function( error, result ) {
           if ( error ) {
             if (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-http2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Detect if a server support http/2",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Its [hard](https://apple.stackexchange.com/questions/208478/how-do-i-disable-system-integrity-protection-sip-aka-rootless-on-os-x-10-11/208481#208481) to update openssl in macos. Would be easier to overwrite default openssl command with a custom one i.e. from Homebrew: 

```
isHttp2(url, { 
  includeSpdy: true,
  openssl: '/usr/local/Cellar/openssl/1.0.2k/bin/openssl'
})
```